### PR TITLE
Fix ampersand entity in return url

### DIFF
--- a/src/upload/catalog/model/extension/payment/yandex_money/yandex-checkout-sdk-php/lib/Request/Payments/CreatePaymentRequestSerializer.php
+++ b/src/upload/catalog/model/extension/payment/yandex_money/yandex-checkout-sdk-php/lib/Request/Payments/CreatePaymentRequestSerializer.php
@@ -135,7 +135,7 @@ class CreatePaymentRequestSerializer
                 if ($confirmation->getEnforce()) {
                     $result['confirmation']['enforce'] = $confirmation->getEnforce();
                 }
-                $result['confirmation']['return_url'] = $confirmation->getReturnUrl();
+                $result['confirmation']['return_url'] = html_entity_decode($confirmation->getReturnUrl());
             }
         }
         if ($request->hasMetadata()) {


### PR DESCRIPTION
Before: https://example.site/index.php?route=account/order/info&amp;order_id=1
After: https://example.site/index.php?route=account/order/info&order_id=1

Tested on ocStore 3.0.2.0